### PR TITLE
Implement support for embedded gift redeem links, and reduce permission level

### DIFF
--- a/announcecodes/announcecodes.py
+++ b/announcecodes/announcecodes.py
@@ -15,7 +15,8 @@ class AnnounceCodes(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=["ac", "announcecode"])
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @commands.cooldown(rate=1, per=60)
+    @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def announcecodes(self, ctx: commands.Context, *codes):
         """Announce HSR gift code(s) quickly.
 

--- a/announcecodes/announcecodes.py
+++ b/announcecodes/announcecodes.py
@@ -15,7 +15,7 @@ class AnnounceCodes(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=["ac", "announcecode"])
-    @commands.cooldown(rate=1, per=60)
+    @commands.cooldown(rate=2, per=60)
     @checks.has_permissions(PermissionLevel.SUPPORTER)
     async def announcecodes(self, ctx: commands.Context, *codes):
         """Announce HSR gift code(s) quickly.

--- a/announcecodes/announcecodes.py
+++ b/announcecodes/announcecodes.py
@@ -32,19 +32,22 @@ class AnnounceCodes(commands.Cog):
         channel = self.bot.get_channel(CHANNEL_ID)
         embed = discord.Embed(
             title=f"New HSR Gift Code{'s' if len(codes) > 1 else ''}!",
-            description="To copy a code on mobile, tap and hold the code itself.",
+            description="You can quickly redeem a code by pressing the respective button below. "
+                        "Alternatively, you can manually redeem by copying the codes in the embed. "
+                        "To copy a code on mobile, tap and hold the code itself.",
             colour=0x7a7dfd
         )
+        view = discord.ui.View()
         for num, code in enumerate(codes):
             name = f"Code {num + 1}"
             if ":" in code:
                 code, name = code.split(":", 1)
-            embed.add_field(name=name, value=code.upper(), inline=False)
+            code = code.upper()
+            embed.add_field(name=name, value=code, inline=False)
+            view.add_item(discord.ui.Button(label=f"Redeem {name}", style=discord.ButtonStyle.url, url=f"https://hsr.hoyoverse.com/gift?code={code}"))
 
         msg = await ctx.reply("Announcing...")
-        await channel.send(content=f"<@&{CODES_ROLE_ID}>", embed=embed, view=discord.ui.View().add_item(
-            discord.ui.Button(label="Redeem Page", style=discord.ButtonStyle.url,
-                              url="https://hsr.hoyoverse.com/gift")))
+        await channel.send(content=f"<@&{CODES_ROLE_ID}>", embed=embed, view=view)
         await msg.edit(content="Codes have been announced")
 
 


### PR DESCRIPTION
HSR's code redeem site implemented support for embedding codes into links, so we've moved towards using those (codes are still available for manual input).

Additionally, the PermissionLevel required to use the announcecodes command was reduced to Supporter (and a cooldown added to deter abuse), as authorized per [this conversation](https://discord.com/channels/896299867972964383/896803697223401522/1154105861329920141).