### PR TITLE
Revamp Counting Plugin

### DIFF
--- a/counting/counting.py
+++ b/counting/counting.py
@@ -29,7 +29,7 @@ class Counting(commands.Cog):
         self.bot = bot
         self.channel = bot.get_channel(COUNTING_CHANNEL)
         self.last_number = None
-        self.last_message = None  # For use in detecting notable message edits & deletes
+        self.last_message = None  # DO NOT RELY ON FOR CURRENT #, use self.last_number instead
         self.lock = asyncio.Lock()  # To prevent dual-processing edge-cases
 
     async def fail(self, title: str, message: discord.Message):
@@ -85,7 +85,7 @@ class Counting(commands.Cog):
             content = get_simplified_contents(default_message)
             if content.isdigit():
                 self.last_number = int(content) - 1
-                self.last_message = await self.channel.send(content=str(self.last_number))  # So double-count doesn't kick in
+                self.last_message = await self.channel.send(content="*Count Recovered - Ignore This Message*")  # So double-count doesn't kick in
                 return
 
         self.last_number = 0

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -85,7 +85,7 @@ class Counting(commands.Cog):
             content = get_simplified_contents(default_message)
             if content.isdigit():
                 self.last_number = int(content) - 1
-                self.last_message = default_message
+                self.last_message = await self.channel.send(content=str(self.last_number))  # So double-count doesn't kick in
                 return
 
         self.last_number = 0

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -31,15 +31,13 @@ class Counting(commands.Cog):
                 await message.add_reaction('❌')
                 embed = discord.Embed(
                     title="That doesn't look right! Better luck next time :)",
-                    description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.",
+                    description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.\n\n"
+                                "*If this detection appears incorrect, please report it to the bot development team.*",
                     colour=discord.Colour.red()
                 )
                 embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
                 embed.set_thumbnail(
                     url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
-                )
-                embed.set_footer(
-                    text="*If this detection appears incorrect, please report it to the bot development team.*"
                 )
                 self.last_number = 0
                 self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
@@ -47,8 +45,8 @@ class Counting(commands.Cog):
         else:  # Not a number
             # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
             embed = discord.Embed(description=message.content)
-            embed.set_author(name=f"{message.author.display_name} (`{message.author.id}`)", icon_url=message.author.display_avatar.url)
-            embed.set_footer(text=f"*The count is currently at: **`{self.last_number:,d}`***")
+            embed.set_author(name=f"{message.author.display_name} ({message.author.id})", icon_url=message.author.display_avatar.url)
+            embed.add_field(name="​", value=f"*The count is currently at: **`{self.last_number}`***")
             await message.delete()
             return await message.channel.send(embed=embed)
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -1,22 +1,24 @@
 import discord
 from discord.ext import commands
 
+COUNTING_CHANNEL = 1162804188800102501
+
+
 class Counting(commands.Cog):
     """Counting Plugin"""
 
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.lastnumber = 0
-        
-        
+        self.last_number = 0
+
     @commands.Cog.listener("on_message")
-    async def check_number(self, message: discord.Message):
-        if message.channel.id == 1162804188800102501 and message.author.id != 902093847889313833:
+    async def counting_on_message(self, message: discord.Message):
+        if message.channel.id == COUNTING_CHANNEL and message.author.id != self.bot.user.id:
             if message.content.isdigit():
-                expected_number = self.lastnumber + 1
+                expected_number = self.last_number + 1
                 if int(message.content) == expected_number:
                     await message.add_reaction('✅')
-                    self.lastnumber = expected_number
+                    self.last_number = expected_number
                 else:
                     dumb = message.author.display_name
                     await message.add_reaction('❌')
@@ -24,16 +26,16 @@ class Counting(commands.Cog):
                         title=f"{dumb} doesn't know how to count",
                         colour=discord.Colour.red()
                     )
-                    embed.add_field(name="Highest number reached", value=self.lastnumber)
+                    embed.add_field(name="Highest number reached", value=self.last_number)
                     embed.add_field(name="The Count has been reset to 0", value="Good luck next time")
                     embed.set_thumbnail(
                         url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
                     )
                     await message.channel.send(embed=embed)
-                    self.lastnumber = 0
+                    self.last_number = 0
             else:
                 await message.channel.send("please refrain from typing in this channel")
 
+
 async def setup(bot):
     await bot.add_cog(Counting(bot))
-

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -8,7 +8,11 @@ DUPLICATE_GRACE = 0.75  # Time in seconds to be lenient to duplicate messages
 
 
 def set_embed_author(embed: discord.Embed, member: discord.Member):
-    """Sets the author field for an embed from a member object, following a predefined format."""
+    """Sets the author field for an embed from a member object, following a predefined format.
+
+    :param embed: Embed to set the author for
+    :param member: Member object you want to get the data from
+    """
     embed.set_author(name=f"{member.display_name} ({member.id})", icon_url=member.display_avatar.url)
 
 
@@ -20,6 +24,27 @@ class Counting(commands.Cog):
         self.last_number = 0
         self.last_message = None  # For use in detecting notable message edits & deletes
         self.lock = asyncio.Lock()  # To prevent dual-processing edge-cases
+
+    async def fail(self, title: str, message: discord.Message):
+        """Method to send a count-failed message with a customizable title.
+
+        :param title: Title to use for the count-failed embed
+        :param message: Message that resulted in the count-fail
+        """
+        await message.add_reaction('❌')
+        embed = discord.Embed(
+            title=title,
+            description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.\n\n"
+                        "*If this detection appears incorrect, please report it to the bot development team.*",
+            colour=discord.Colour.red()
+        )
+        embed.set_thumbnail(
+            url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
+        )
+        set_embed_author(embed, message.author)
+        self.last_number = 0
+        self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
+        return
 
     @commands.Cog.listener("on_message")
     async def counting_on_message(self, message: discord.Message):
@@ -36,37 +61,36 @@ class Counting(commands.Cog):
                 current_number = int(message.content.strip())
                 expected_number = self.last_number + 1
 
-                if current_number == expected_number:  # They can count!
-                    self.last_number = current_number
-                    self.last_message = message
-                    return await message.add_reaction('✅')
-                else:  # They can't count :(
-                    await message.add_reaction('❌')
-
+                if current_number != expected_number:  # They can't count :(
                     # Grace period for when people send the same number at the same time
                     if current_number == self.last_number and message.author.id != self.last_message.author.id and (
                             message.created_at - self.last_message.created_at
                     ).total_seconds() <= DUPLICATE_GRACE:
+                        await message.add_reaction('❌')
                         return await message.reply(embed=discord.Embed(
                             title="That doesn't look right, but I'll give you a chance...",
                             description=f"{message.author.mention} sent a duplicate number, but within the grace period. "
                                         f"The count is still at **{self.last_number:,d}**.",
                             colour=discord.Colour.yellow()
                         ))
+                    return await self.fail("That doesn't look right! Better luck next time :)", message)
+                elif message.author.id == self.last_message.author.id:  # They're trying to count by themselves!
+                    return await self.fail("You can't count twice in a row!", message)
+                elif self.last_message.author.id == self.bot.user.id and len(self.last_message.embeds) > 0:
+                    embed = self.last_message.embeds[0]
+                    if ("editing" in embed.description or "deleting" in embed.description
+                    ) and str(message.author.id) in embed.author.name:  # Not a edit/delete message resulting from them
+                        await message.reply(
+                            content="Don't try to edit or delete your messages to get around detections please.\n"
+                                    "If you're seeing this by pure coincidence, don't worry about it.",
+                            delete_after=10
+                        )
+                        return await self.fail("You can't count twice in a row!", message)
 
-                    embed = discord.Embed(
-                        title="That doesn't look right! Better luck next time :)",
-                        description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.\n\n"
-                                    "*If this detection appears incorrect, please report it to the bot development team.*",
-                        colour=discord.Colour.red()
-                    )
-                    embed.set_thumbnail(
-                        url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
-                    )
-                    set_embed_author(embed, message.author)
-                    self.last_number = 0
-                    self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
-                    return
+                # They can count!
+                self.last_number = current_number
+                self.last_message = message
+                return await message.add_reaction('✅')
             else:  # Not a number
                 # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
                 embed = discord.Embed(description=message.content, colour=discord.Colour.light_gray())

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import discord
 from discord.ext import commands
 
@@ -10,7 +12,8 @@ class Counting(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.last_number = 0
-        self.last_message = None
+        self.last_message = None  # For use in detecting notable message edits & deletes
+        self.lock = asyncio.Lock()  # To prevent dual-processing edge-cases
 
     @commands.Cog.listener("on_message")
     async def counting_on_message(self, message: discord.Message):
@@ -19,36 +22,37 @@ class Counting(commands.Cog):
         if message.channel.id != COUNTING_CHANNEL:  # Not the counting channel
             return
 
-        if message.content.strip().isdigit():  # Is a number
-            current_number = int(message.content.strip())
-            expected_number = self.last_number + 1
+        async with self.lock:
+            if message.content.strip().isdigit():  # Is a number
+                current_number = int(message.content.strip())
+                expected_number = self.last_number + 1
 
-            if current_number == expected_number:  # They can count!
-                self.last_number = current_number
-                self.last_message = message
-                return await message.add_reaction('✅')
-            else:  # They can't count :(
-                await message.add_reaction('❌')
-                embed = discord.Embed(
-                    title="That doesn't look right! Better luck next time :)",
-                    description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.\n\n"
-                                "*If this detection appears incorrect, please report it to the bot development team.*",
-                    colour=discord.Colour.red()
-                )
-                embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
-                embed.set_thumbnail(
-                    url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
-                )
-                self.last_number = 0
-                self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
-                return
-        else:  # Not a number
-            # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
-            embed = discord.Embed(description=message.content)
-            embed.set_author(name=f"{message.author.display_name} ({message.author.id})", icon_url=message.author.display_avatar.url)
-            embed.add_field(name="​", value=f"*The count is currently at: **`{self.last_number}`***")
-            await message.delete()
-            return await message.channel.send(embed=embed)
+                if current_number == expected_number:  # They can count!
+                    self.last_number = current_number
+                    self.last_message = message
+                    return await message.add_reaction('✅')
+                else:  # They can't count :(
+                    await message.add_reaction('❌')
+                    embed = discord.Embed(
+                        title="That doesn't look right! Better luck next time :)",
+                        description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.\n\n"
+                                    "*If this detection appears incorrect, please report it to the bot development team.*",
+                        colour=discord.Colour.red()
+                    )
+                    embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
+                    embed.set_thumbnail(
+                        url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
+                    )
+                    self.last_number = 0
+                    self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
+                    return
+            else:  # Not a number
+                # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
+                embed = discord.Embed(description=message.content)
+                embed.set_author(name=f"{message.author.display_name} ({message.author.id})", icon_url=message.author.display_avatar.url)
+                embed.add_field(name="​", value=f"*The count is currently at: **`{self.last_number}`***")
+                await message.delete()
+                return await message.channel.send(embed=embed)
 
 
 async def setup(bot):

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -10,31 +10,47 @@ class Counting(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.last_number = 0
+        self.last_message = None
 
     @commands.Cog.listener("on_message")
     async def counting_on_message(self, message: discord.Message):
-        if message.channel.id == COUNTING_CHANNEL and message.author.id != self.bot.user.id:
-            if message.content.isdigit():
-                expected_number = self.last_number + 1
-                if int(message.content) == expected_number:
-                    await message.add_reaction('✅')
-                    self.last_number = expected_number
-                else:
-                    dumb = message.author.display_name
-                    await message.add_reaction('❌')
-                    embed = discord.Embed(
-                        title=f"{dumb} doesn't know how to count",
-                        colour=discord.Colour.red()
-                    )
-                    embed.add_field(name="Highest number reached", value=self.last_number)
-                    embed.add_field(name="The Count has been reset to 0", value="Good luck next time")
-                    embed.set_thumbnail(
-                        url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
-                    )
-                    await message.channel.send(embed=embed)
-                    self.last_number = 0
-            else:
-                await message.channel.send("please refrain from typing in this channel")
+        if not message.author or not message.author.guild or message.author.bot:  # Irrelevant
+            return
+        if message.channel.id != COUNTING_CHANNEL:  # Not the counting channel
+            return
+
+        if message.content.strip().isdigit():  # Is a number
+            current_number = int(message.content.strip())
+            expected_number = self.last_number + 1
+
+            if current_number == expected_number:  # They can count!
+                self.last_number = current_number
+                self.last_message = message
+                return await message.add_reaction('✅')
+            else:  # They can't count :(
+                await message.add_reaction('❌')
+                embed = discord.Embed(
+                    title="That doesn't look right! Better luck next time :)",
+                    description=f"{message.author.mention} ruined the count at **{self.last_number:,d}**. Next number is **1**.",
+                    colour=discord.Colour.red()
+                )
+                embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
+                embed.set_thumbnail(
+                    url="https://img-os-static.hoyolab.com/communityWeb/upload/19dacf2bf7dad6cea3b4a1d8d68045a0.png"
+                )
+                embed.set_footer(
+                    text="*If this detection appears incorrect, please report it to the bot development team.*"
+                )
+                self.last_number = 0
+                self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
+                return
+        else:  # Not a number
+            # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
+            embed = discord.Embed(description=message.content)
+            embed.set_author(name=f"{message.author.display_name} (`{message.author.id}`)", icon_url=message.author.display_avatar.url)
+            embed.set_footer(text=f"*The count is currently at: **`{self.last_number:,d}`***")
+            await message.delete()
+            return await message.channel.send(embed=embed)
 
 
 async def setup(bot):

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -50,7 +50,9 @@ class Counting(commands.Cog):
         )
         set_embed_author(embed, message.author)
         self.last_number = 0
-        self.last_message = await message.channel.send(content="0", embed=embed)  # "0" content allows for count detection on restart
+        self.last_message = await message.channel.send(
+            content="0", embed=embed
+        )  # "0" content allows for count detection on restart
         return
 
     async def assert_last(self, default_message: discord.Message = None):
@@ -144,7 +146,10 @@ class Counting(commands.Cog):
             else:  # Not a number
                 # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
                 embed = discord.Embed(description=message.content, colour=discord.Colour.light_gray())
-                embed.add_field(name="​", value=f"*The count is currently at: **`{self.last_number:,d}`***")
+                embed.add_field(
+                    name="​",
+                    value=f"*The count is currently at: **`{self.last_number:,d}`**, by {self.last_message.author.mention}*"
+                )
                 set_embed_author(embed, message.author)
                 await message.delete()
                 return await message.channel.send(embed=embed)

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 COUNTING_CHANNEL = 1162804188800102501
+DEVELOPER_ROLE = 1087928500893265991
 DUPLICATE_GRACE = 0.75  # Time in seconds to be lenient to duplicate messages
 
 
@@ -127,6 +128,17 @@ class Counting(commands.Cog):
         )
         set_embed_author(embed, message.author)
         self.last_message = await message.channel.send(content=str(self.last_number), embed=embed)
+
+    @commands.command()
+    @commands.has_role(DEVELOPER_ROLE)
+    async def countingoverride(self, ctx: commands.Context, number: int):
+        """Override the current count in counting"""
+        self.last_number = number
+        self.last_message = await self.bot.get_channel(COUNTING_CHANNEL).send(content=str(number), embed=discord.Embed(
+            title="Count Overridden!",
+            description=f"The current count has been set to: **`{number:,d}`** by {ctx.author.mention}.",
+            colour=discord.Colour.green()
+        ))
 
 
 async def setup(bot):

--- a/counting/requirements.txt
+++ b/counting/requirements.txt
@@ -1,0 +1,1 @@
+simpleeval==0.9.13


### PR DESCRIPTION
List of (major) changes include:
- Prevented parallel message processing (edge case)
- Gave a grace period for duplicate numbers
- Added protections for message edits and deletions
- Prevented users from counting twice in a row
- Added a command to override the count, accessible by anyone with the Bot Dev role (does not use MM permissions, this command will pretty much only be used when bugs happen, and devs are usually the ones investigating anyway)
- Added a multitude of recovery methods for when the bot loses track of the count
- Changed up how bot handles chat messages
- Can now (safely) evaluate a wide variety of expressions to use in place of literal

Don't forget the `?plugin update` :)