### PR TITLE
Update & Patch for Counting

### DIFF
--- a/counting/counting.py
+++ b/counting/counting.py
@@ -97,7 +97,9 @@ def set_embed_footer(embed: discord.Embed, additional: str = None) -> discord.Em
     return embed
 
 
-def set_embed_author_footer(embed: discord.Embed, member: discord.Member, additional: str = None) -> discord.Embed:
+def set_embed_author_footer(
+    embed: discord.Embed, member: discord.Member, additional: str = None
+) -> discord.Embed:
     """Combination of set_embed_author and set_embed_footer, for quick-creations
 
     :param embed: Embed to set the author and footer for
@@ -126,10 +128,13 @@ async def expression_reply(
     :return: Replied message object
     """
     return await message.reply(
-        embed=set_embed_footer(discord.Embed(
-            description=f"{get_exp_code(exp)}\n{content}",
-            colour=discord.Colour.dark_grey(),
-        ), f"This message will delete itself in {delete_after} seconds."),
+        embed=set_embed_footer(
+            discord.Embed(
+                description=f"{get_exp_code(exp)}\n{content}",
+                colour=discord.Colour.dark_grey(),
+            ),
+            f"This message will delete itself in {delete_after} seconds.",
+        ),
         delete_after=delete_after,
         **kwargs,
     )
@@ -349,13 +354,15 @@ class Counting(commands.Cog):
         self.last_number = 0
         self.last_message = await self.channel.send(
             content="0",
-            embed=set_embed_footer(discord.Embed(
-                title="Count Reset to 0",
-                description="I was unable to find any previous counting data, through any recovery method. As a result, "
-                "the count has been reset to 0. This should almost never happen, please contact a bot "
-                "developer if you see this in normal operational circumstances.\n\nNext number is **1**.",
-                colour=discord.Colour.red(),
-            )),
+            embed=set_embed_footer(
+                discord.Embed(
+                    title="Count Reset to 0",
+                    description="I was unable to find any previous counting data, through any recovery method. As a result, "
+                    "the count has been reset to 0. This should almost never happen, please contact a bot "
+                    "developer if you see this in normal operational circumstances.\n\nNext number is **1**.",
+                    colour=discord.Colour.red(),
+                )
+            ),
         )
 
     @commands.Cog.listener("on_message")
@@ -392,13 +399,15 @@ class Counting(commands.Cog):
                     ):
                         await message.add_reaction("❌")
                         return await message.reply(
-                            embed=set_embed_footer(discord.Embed(
-                                title="That doesn't look right, but I'll give you a chance...",
-                                description=f"{message.author.mention} sent a duplicate number, but within the grace period. "
-                                f"The count is still at {self.get_representation()} "
-                                f"(by {self.last_message.author.mention}).",
-                                colour=discord.Colour.yellow(),
-                            ))
+                            embed=set_embed_footer(
+                                discord.Embed(
+                                    title="That doesn't look right, but I'll give you a chance...",
+                                    description=f"{message.author.mention} sent a duplicate number, but within the grace period. "
+                                    f"The count is still at {self.get_representation()} "
+                                    f"(by {self.last_message.author.mention}).",
+                                    colour=discord.Colour.yellow(),
+                                )
+                            )
                         )
 
                     return await self.fail(
@@ -486,11 +495,15 @@ class Counting(commands.Cog):
 
             # Do not remove the "editing" portion of the embed, other segments of code look for that as a keyword
             self.last_message = await before.channel.send(
-                content=str(self.last_number), embed=set_embed_author_footer(discord.Embed(
-                    description=f"{before.author.mention} tried editing their message...\n\n"
-                                f"The count is currently at: {self.get_representation()}",
-                    colour=discord.Colour.green(),
-                ), before.author)
+                content=str(self.last_number),
+                embed=set_embed_author_footer(
+                    discord.Embed(
+                        description=f"{before.author.mention} tried editing their message...\n\n"
+                        f"The count is currently at: {self.get_representation()}",
+                        colour=discord.Colour.green(),
+                    ),
+                    before.author,
+                ),
             )
             await before.delete()  # Delete original message after self.last_message is set, to prevent triggering deletion detection
 
@@ -508,11 +521,15 @@ class Counting(commands.Cog):
 
             # Do not remove the "deleting" portion of the embed, other segments of code look for that as a keyword
             self.last_message = await message.channel.send(
-                content=str(self.last_number), embed=set_embed_author_footer(discord.Embed(
-                    description=f"{message.author.mention} tried deleting their message...\n\n"
-                                f"The count is currently at: {self.get_representation()}",
-                    colour=discord.Colour.dark_green(),
-                ), message.author)
+                content=str(self.last_number),
+                embed=set_embed_author_footer(
+                    discord.Embed(
+                        description=f"{message.author.mention} tried deleting their message...\n\n"
+                        f"The count is currently at: {self.get_representation()}",
+                        colour=discord.Colour.dark_green(),
+                    ),
+                    message.author,
+                ),
             )
 
     @commands.Cog.listener("on_reaction_add")
@@ -551,11 +568,13 @@ class Counting(commands.Cog):
         self.last_number = number
         self.last_message = await self.channel.send(
             content=str(number),
-            embed=set_embed_footer(discord.Embed(
-                title="Count Overridden!",
-                description=f"The current count has been set to: **`{number:,d}`** by {ctx.author.mention}.",
-                colour=discord.Colour.green(),
-            )),
+            embed=set_embed_footer(
+                discord.Embed(
+                    title="Count Overridden!",
+                    description=f"The current count has been set to: **`{number:,d}`** by {ctx.author.mention}.",
+                    colour=discord.Colour.green(),
+                )
+            ),
         )
 
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -15,7 +15,7 @@ VERSION = "2.1.0"
 COUNTING_CHANNEL = 1162804188800102501
 DEVELOPER_ROLE = 1087928500893265991
 EVALUATION_TIMEOUT = 2  # Time in seconds after which to timeout
-DUPLICATE_GRACE = 0.75  # Time in seconds to be lenient to duplicate messages
+DUPLICATE_GRACE = 1  # Time in seconds to be lenient to duplicate messages
 CODE_BLOCK_REGEX = re.compile(
     r"(?P<delim>(?P<block>```)|``?)(?(block)(?:(?P<lang>[a-z]+)\n)?)(?:[ \t]*\n)*(?P<code>.*?)\s*(?P=delim)",
     re.DOTALL | re.IGNORECASE,

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -240,7 +240,7 @@ class Counting(commands.Cog):
                 )
                 set_embed_author(embed, message.author)
                 await message.delete()
-                return await message.channel.send(embed=embed)
+                return await message.channel.send(embed=embed, reference=message.reference, mention_author=False)
 
     @commands.Cog.listener("on_message_edit")
     async def counting_on_message_edit(self, before: discord.Message, after: discord.Message):

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -1,6 +1,7 @@
 import ast
 import asyncio
 import math
+import operator as op
 import re
 
 import discord
@@ -50,6 +51,8 @@ s.functions.update(  # Add additional functions
     degrees=math.degrees,  # Offer rad -> deg conversion
     radians=math.radians,  # Offer deg -> rad conversion
     abs=abs,
+    bitxor=op.xor,  # Reimplement bitwise XOR (^), which was removed to curb symbol confusion
+    bitor=op.or_,  # Reimplement bitwise OR (|), which was removed to curb symbol confusion
 )
 s.names.update(  # Add additional variables
     pi=math.pi,

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -38,6 +38,17 @@ s.functions.update(  # Add additional functions
     sqrt=math.sqrt,
     sqroot=math.sqrt,
     squareroot=math.sqrt,
+    sin=lambda x: math.sin(
+        math.radians(x)
+    ),  # sin takes radians, input as degrees is simpler, so convert deg -> rad
+    cos=lambda x: math.cos(
+        math.radians(x)
+    ),  # cos takes radians, input as degrees is simpler, so convert deg -> rad
+    tan=lambda x: math.tan(
+        math.radians(x)
+    ),  # tan takes radians, input as degrees is simpler, so convert deg -> rad
+    degrees=math.degrees,  # Offer rad -> deg conversion
+    radians=math.radians,  # Offer deg -> rad conversion
     abs=abs,
 )
 s.names.update(  # Add additional variables

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -239,8 +239,14 @@ class Counting(commands.Cog):
                     value=f"*The count is currently at:* {self.get_representation()} (*by {self.last_message.author.mention}*)"
                 )
                 set_embed_author(embed, message.author)
+                files = []
+                if len(message.attachments) > 0:
+                    for attach in message.attachments:
+                        if not attach.content_type or not attach.content_type.startswith("image/"):
+                            continue
+                        files.append(await attach.to_file())
                 await message.delete()
-                return await message.channel.send(embed=embed, reference=message.reference, mention_author=False)
+                return await message.channel.send(embed=embed, reference=message.reference, mention_author=False, files=files)
 
     @commands.Cog.listener("on_message_edit")
     async def counting_on_message_edit(self, before: discord.Message, after: discord.Message):

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -28,6 +28,7 @@ s.names.update(  # Add additional variables
     pi=math.pi,
 )
 simpleeval.MAX_POWER = 1000  # We're never getting that far (prevents timely exponent operations)
+simpleeval.MAX_STRING_LENGTH = 10000  # Shouldn't be using strings much anyway (prevents memory exhaustion)
 
 
 def set_embed_author(embed: discord.Embed, member: discord.Member):

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -24,6 +24,9 @@ s.functions.update(  # Add additional functions
     sqrt=math.sqrt,
     abs=abs,
 )
+s.names.update(  # Add additional variables
+    pi=math.pi,
+)
 simpleeval.MAX_POWER = 1000  # We're never getting that far (prevents timely exponent operations)
 
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -37,7 +37,7 @@ s.functions.update(  # Add additional functions
 s.names.update(  # Add additional variables
     pi=math.pi,
 )
-simpleeval.MAX_POWER = 1000  # We're never getting that far (prevents timely exponent operations)
+simpleeval.MAX_POWER = 10000  # We're never getting that far (prevents timely exponent operations)
 simpleeval.MAX_STRING_LENGTH = 10000  # Shouldn't be using strings much anyway (prevents memory exhaustion)
 
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -239,9 +239,13 @@ async def get_num(message: discord.Message, reply: bool = False):
             fail_msg = None
     except (SyntaxError, ValueError, TypeError, ZeroDivisionError) as e:
         err_str = str(e)
-        if err_str.startswith("invalid syntax"):  # False-positives from messages starting with most symbols (?abc)
+        if err_str.startswith(
+            "invalid syntax"
+        ):  # False-positives from messages starting with most symbols (?abc)
             return None
-        elif err_str == "__init__() missing 1 required positional argument: 'expression'":  # odd error that happens with every message
+        elif (
+            err_str == "__init__() missing 1 required positional argument: 'expression'"
+        ):  # odd error that happens with every message
             return None
         fail_msg = f"```py\n{repr(e).replace('`', '[backtick]')}\n```"
     except (Exception,):
@@ -345,6 +349,8 @@ class Counting(commands.Cog):
             if (
                 message.author.bot and message.author.id != self.bot.user.id
             ):  # Bot that isn't us
+                continue
+            if len(message.content) == 0:  # Empty message, don't bother
                 continue
             num = await get_num(message)
             if num is not None:

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -77,10 +77,10 @@ async def safe_eval(string: str):
 
 
 async def get_num(message: discord.Message, reply: bool = False):
-    """Get a number from a user input, potentially containing mathematical expressions
+    """Get a number from a user input, potentially containing mathematical expressions.
 
     :param message: Message to get the input from
-    :param reply: Whether to reply to the user in select fail-evaluate circumstances
+    :param reply: Whether to reply to the user with details in select fail-evaluate circumstances
     :return: Number if successful, None if unsuccessful
     """
     simple_contents = message.content.strip().replace(",", "")
@@ -125,7 +125,7 @@ async def get_num(message: discord.Message, reply: bool = False):
     except simpleeval.FunctionNotDefined as e:
         fail_msg = f"The function `{getattr(e, 'func_name').replace('`', '[backtick]')}` does not exist."
     except simpleeval.OperatorNotDefined as e:
-        fail_msg = f"The operator `{e.attr}` does not exist."
+        fail_msg = f"The operator `{e.attr.replace('`', '[backtick]')}` does not exist."
     except (Exception,):
         pass
     if reply and fail_msg is not None:
@@ -150,7 +150,8 @@ class Counting(commands.Cog):
             await self.assert_last(only_history=True)
 
     def get_representation(self):
-        """Get a representation of the last number, returning the number itself by default, but the message instead for expressions, escaped as needed."""
+        """Get a representation of the last number, returning the number itself by default, but a code block
+         instead for expressions, escaped as needed."""
         assert self.last_number is not None and self.last_message is not None
         self.last_message: discord.Message
         if self.last_message.author.bot or str(self.last_number) == self.last_message.content:

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -45,7 +45,7 @@ async def safe_eval(string: str):
     return s.eval(string)
 
 
-async def get_num(message: discord.Message):
+async def get_num(message: discord.Message, reply: bool = False):
     """Get a number from a user input, potentially containing mathematical expressions"""
     simple_contents = message.content.strip().replace(",", "")
     if simple_contents.isdigit():
@@ -62,16 +62,17 @@ async def get_num(message: discord.Message):
             if eval_output.is_integer():  # Float type, but whole number
                 eval_output = int(eval_output)  # Convert to integer so it succeeds int check later
             else:  # Float type, not a whole number
-                await message.reply(embed=discord.Embed(
-                    description=f"I've calculated:\n```py\n{content.replace('`','[backtick]')}\n```\n= "
-                                f"*`{eval_output}`*\n\nTo prevent unexpected behaviour, I do not automatically convert"
-                                "decimal numbers to whole numbers. You can do this yourself with:\n"
-                                "- `int(your content)`/`floor(your content)`: Rounds down (truncates)\n"
-                                "- `ceil(your content)`: Rounds up\n"
-                                "- `round(your content)`: Rounds (<= 0.5 down, > 0.5 up)\n"
-                                "- `dividend//divisor`: Floor division, divides then rounds down (truncates)",
-                    colour=discord.Colour.dark_grey()
-                ), delete_after=15)
+                if reply:
+                    await message.reply(embed=discord.Embed(
+                        description=f"I've calculated:\n```py\n{content.replace('`','[backtick]')}\n```\n= "
+                                    f"*`{eval_output}`*\n\nTo prevent unexpected behaviour, I do not automatically "
+                                    "convert decimal numbers to whole numbers. You can do this yourself with:\n"
+                                    "- `int(your content)`/`floor(your content)`: Rounds down (truncates)\n"
+                                    "- `ceil(your content)`: Rounds up\n"
+                                    "- `round(your content)`: Rounds (<= 0.5 down, > 0.5 up)\n"
+                                    "- `dividend//divisor`: Floor division, divides then rounds down (truncates)",
+                        colour=discord.Colour.dark_grey()
+                    ), delete_after=15)
                 return None
 
         if isinstance(eval_output, int):
@@ -199,7 +200,7 @@ class Counting(commands.Cog):
 
         async with self.lock:  # Utilize async lock to prevent parallel message processing edge cases
             await self.assert_last(message)  # Ensure self.last_number and self.last_message exists
-            current_number = await get_num(message)
+            current_number = await get_num(message, reply=True)
             if current_number is not None:  # Is a number
                 expected_number = self.last_number + 1
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -146,7 +146,8 @@ async def get_num(message: discord.Message, reply: bool = False):
                         content,
                         f"= *`{eval_output}`*\n\nTo prevent unexpected behaviour, I do not automatically convert "
                         "decimal numbers to whole numbers. You can do this yourself with:\n"
-                        "- `int(your content)`/`floor(your content)`: Rounds down (truncates)\n"
+                        "- `int(your content)`: Truncates (ignores all decimals)\n"
+                        "- `floor(your content)`: Rounds down\n"
                         "- `ceil(your content)`: Rounds up\n"
                         "- `round(your content)`: Rounds (<= 0.5 down, > 0.5 up)\n"
                         "- `dividend//divisor`: Floor division, divides then rounds down (truncates)",

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -401,9 +401,24 @@ class Counting(commands.Cog):
         if message.channel.id != COUNTING_CHANNEL:  # Not the counting channel
             return
 
-        # Special Messages
+        # Special Messages (Keyword)
         if message.content.lower() == "help":
-            pass
+            msg = await message.reply(
+                embed=set_embed_author_footer(
+                    discord.Embed(
+                        title="Need Help?",
+                        description="[View the Documentation](https://gist.github.com/blankdvth/"
+                        "2b2a5ac9b4c4d93b5d682390a1a3d2f0#counting-documentation)\n\nThe documentation "
+                        "includes the basic rules of the game, supported syntax, available functions & "
+                        "variables, and more. If you have any questions beyond the documentation, "
+                        "you can ask here, or ask one of the bot developers.",
+                        colour=discord.Colour.dark_grey(),
+                    ),
+                    message.author,
+                )
+            )
+            await message.delete()
+            return await msg.add_reaction("🗑️")
 
         async with self.lock:  # Utilize async lock to prevent parallel message processing edge cases
             await self.assert_last(

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -176,16 +176,18 @@ async def get_num(message: discord.Message, reply: bool = False):
     try:
         eval_output, ws = safe_eval(content).result()
         # Handle all warnings
-        for w in ws:
-            if w.category in [
-                simpleeval.AssignmentAttempted,
-                simpleeval.MultipleExpressions,
-            ]:
-                await expression_reply(
-                    message,
-                    content,
-                    f"```py\n{w.message.replace('`', '[backtick]')}```",
-                )
+        if reply:
+            for w in ws:
+                if w.category in [
+                    simpleeval.AssignmentAttempted,
+                    simpleeval.MultipleExpressions,
+                ]:
+                    msg = str(w.message).replace("\n", "\\n").replace("`", "[backtick]")
+                    await expression_reply(
+                        message,
+                        content,
+                        f"`{msg}`",
+                    )
 
         if isinstance(eval_output, float):
             if eval_output.is_integer():  # Float type, but whole number

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -58,6 +58,7 @@ s.functions.update(  # Add additional functions
 )
 s.names.update(  # Add additional variables
     pi=math.pi,
+    e=math.e,
 )
 simpleeval.MAX_POWER = (
     10000  # We're never getting that far (prevents timely exponent operations)

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -90,11 +90,13 @@ async def expression_reply(
     :param kwargs: kwargs to relay to message.reply()
     :return: Replied message object
     """
+    embed = discord.Embed(
+        description=f"{get_exp_code(exp)}\n{content}",
+        colour=discord.Colour.dark_grey(),
+    )
+    embed.set_footer(text=f"This message will delete itself in {delete_after} seconds.")
     return await message.reply(
-        embed=discord.Embed(
-            description=f"{get_exp_code(exp)}\n{content}",
-            colour=discord.Colour.dark_grey(),
-        ),
+        embed=embed,
         delete_after=delete_after,
         **kwargs,
     )
@@ -136,12 +138,13 @@ async def get_num(message: discord.Message, reply: bool = False):
                     await expression_reply(
                         message,
                         content,
-                        f"= *{eval_output}*\n\nTo prevent unexpected behaviour, I do not automatically convert"
+                        f"= *`{eval_output}`*\n\nTo prevent unexpected behaviour, I do not automatically convert "
                         "decimal numbers to whole numbers. You can do this yourself with:\n"
                         "- `int(your content)`/`floor(your content)`: Rounds down (truncates)\n"
                         "- `ceil(your content)`: Rounds up\n"
                         "- `round(your content)`: Rounds (<= 0.5 down, > 0.5 up)\n"
                         "- `dividend//divisor`: Floor division, divides then rounds down (truncates)",
+                        delete_after=30,
                     )
                 return None
 
@@ -156,11 +159,6 @@ async def get_num(message: discord.Message, reply: bool = False):
         fail_msg = (
             "An iterable in your expression is way too big -- there are size limits to prevent "
             "memory-expensive operations"
-        )
-    except simpleeval.MultipleExpressions:
-        fail_msg = (
-            "I've detected multiple expressions in your message, only one expression is allowed.\n"
-            "||*(Check for ;'s)*||"
         )
     except simpleeval.FunctionNotDefined as e:
         fail_msg = f"The function `{getattr(e, 'func_name').replace('`', '[backtick]')}` does not exist."

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -95,7 +95,7 @@ def set_embed_footer(embed: discord.Embed, additional: str = None) -> discord.Em
     """
     text = f"Counting Plugin v{VERSION}"
     if additional:
-        text += f"| {additional}"
+        text += f" | {additional}"
     embed.set_footer(text=text)
     return embed
 

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -52,7 +52,9 @@ s.functions.update(  # Add additional functions
     radians=math.radians,  # Offer deg -> rad conversion
     abs=abs,
     bitxor=op.xor,  # Reimplement bitwise XOR (^), which was removed to curb symbol confusion
-    bitor=op.or_,  # Reimplement bitwise OR (|), which was removed to curb symbol confusion
+    bitor=op.or_,  # Reimplement bitwise OR (|), which was removed to curb symbol confusion,
+    log=lambda x, base=10: math.log(x, base),  # Log with default base 10
+    ln=math.log,  # Default math.log (base e)
 )
 s.names.update(  # Add additional variables
     pi=math.pi,

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -77,7 +77,12 @@ async def safe_eval(string: str):
 
 
 async def get_num(message: discord.Message, reply: bool = False):
-    """Get a number from a user input, potentially containing mathematical expressions"""
+    """Get a number from a user input, potentially containing mathematical expressions
+
+    :param message: Message to get the input from
+    :param reply: Whether to reply to the user in select fail-evaluate circumstances
+    :return: Number if successful, None if unsuccessful
+    """
     simple_contents = message.content.strip().replace(",", "")
     if simple_contents.isdigit():
         return int(simple_contents)
@@ -174,7 +179,7 @@ class Counting(commands.Cog):
                 content = match.group("code")
             else:
                 content = self.last_message.content
-            return get_exp_code(content) + "\n"
+            return f"\n{get_exp_code(content)}\n"
 
     async def fail(self, title: str, message: discord.Message):
         """Method to send a count-failed message with a customizable title.

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -154,7 +154,15 @@ async def get_num(message: discord.Message, reply: bool = False):
     except simpleeval.FunctionNotDefined as e:
         fail_msg = f"The function `{getattr(e, 'func_name').replace('`', '[backtick]')}` does not exist."
     except simpleeval.OperatorNotDefined as e:
-        fail_msg = f"The operator `{e.attr.replace('`', '[backtick]')}` does not exist."
+        try:
+            op_name = e.attr.__class__.__name__
+            fail_msg = f"The operator `{op_name}` does not exist."
+            if op_name == "BitXor":
+                fail_msg += "\nTo perform a power operation, use `**` instead of `^`."
+            elif op_name == "BitOr":
+                fail_msg += "\nTo get an absolute value, use `abs(content here)` instead of `|content here|`."
+        except (Exception,):
+            fail_msg = None
     except (Exception,):
         pass
     if reply and fail_msg is not None:

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -232,6 +232,12 @@ class Counting(commands.Cog):
                 self.last_message = message
                 return await message.add_reaction('✅')
             else:  # Not a number
+                # We're allowing bot developers to explicitly specify that their message should be ignored, for
+                #  circumstances where message resend is not ideal (e.g. when the feature is broken, or for important
+                #  announcements requiring a normal message)
+                if message.content.startswith("//") and DEVELOPER_ROLE in [i.id for i in message.author.roles]:
+                    return
+
                 # We are resending the message as our own embed to allow for the restatement of the number (so it doesn't get lost)
                 embed = discord.Embed(description=message.content, colour=discord.Colour.light_gray())
                 embed.add_field(

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -238,6 +238,11 @@ async def get_num(message: discord.Message, reply: bool = False):
         except (Exception,):
             fail_msg = None
     except (SyntaxError, ValueError, TypeError, ZeroDivisionError) as e:
+        err_str = str(e)
+        if err_str.startswith("invalid syntax"):  # False-positives from messages starting with most symbols (?abc)
+            return None
+        elif err_str == "__init__() missing 1 required positional argument: 'expression'":  # odd error that happens with every message
+            return None
         fail_msg = f"```py\n{repr(e).replace('`', '[backtick]')}\n```"
     except (Exception,):
         pass

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -13,15 +13,25 @@ DUPLICATE_GRACE = 0.75  # Time in seconds to be lenient to duplicate messages
 CODE_BLOCK_REGEX = re.compile(
     r"(?P<delim>(?P<block>```)|``?)(?(block)(?:(?P<lang>[a-z]+)\n)?)(?:[ \t]*\n)*(?P<code>.*?)\s*(?P=delim)",
     re.DOTALL | re.IGNORECASE
-)
+)  # Regex to detect and extra code from Discord code blocks
+
+# Create and configure SimpleEval parser to handle expressions
 s = simpleeval.SimpleEval()
 del s.operators[ast.BitXor]  # ^ symbol, which people may confuse for ** (would override, but syntax is slightly diff)
 del s.operators[ast.BitOr]  # | symbol, which people may confuse for abs
+del s.functions["rand"]  # Randomly generates numbers, would cause griefs more often than not
+del s.functions["randint"]  # Randomly generates numbers, would cause griefs more often than not
 s.functions.update(  # Add additional functions
     floor=math.floor,
+    rounddown=math.floor,
+    round_down=math.floor,
     ceil=math.ceil,
+    roundup=math.ceil,
+    round_up=math.ceil,
     round=round,
     sqrt=math.sqrt,
+    sqroot=math.sqrt,
+    squareroot=math.sqrt,
     abs=abs,
 )
 s.names.update(  # Add additional variables

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -193,6 +193,8 @@ async def get_num(message: discord.Message, reply: bool = False):
                 fail_msg += "\nTo get an absolute value, use `abs(content here)` instead of `|content here|`."
         except (Exception,):
             fail_msg = None
+    except (SyntaxError, ValueError, TypeError, ZeroDivisionError) as e:
+        fail_msg = f"```py\n{repr(e).replace('`', '[backtick]')}\n```"
     except (Exception,):
         pass
     if reply and fail_msg is not None:

--- a/counting/requirements.txt
+++ b/counting/requirements.txt
@@ -1,1 +1,2 @@
 simpleeval==0.9.13
+Pebble==5.0.3


### PR DESCRIPTION
- Have clearer, more descriptive outputs for when user input could not be properly parsed into a number (and we think it's supposed to be a number)
- Add support for replies and image attachments in message resends
- Allow bot devs to bypass message resend mechanism in emergent circumstances (all those with bot dev role, message starting with `//` -- can be edited to remove this later)
- Prevent edge cases with message edit & delete handling
- Add additional functions to evaluator:
	- `floor`/`rounddown`/`round_down`
	- `ceil`/`roundup`/`round_up`
	- `round`: <=0.5 down, >0.5 up
	- `sqrt`/`sqroot`/`squareroot`
	- `sin`
	- `cos`
	- `tan`
	- `degrees`: convert radians -> degrees
	- `radians`: convert degrees -> radians
	- `abs`
	- `bitxor`: Reimplementation of ^ which was removed to prevent confusion (bitwise XOR)
	- `bitor`: Reimplementation of | which was removed to prevent confusion (bitwise OR)
	- `log`: Default base 10 log (customizable via second argument)
	- `ln`: Default natural log (also customizable via second argument)
- Add variables:
	- `pi`: pi
	- `e`: euler's number
- Removed all default random functions, which don't have a realistic use in counting (aside from griefing)
- Raised limit on powers, added (lowered default) a limit for iterables
- Format counting tool using black (opinionated code formatter)
- Allowed the OP to delete select messages via reaction
- Relay warnings to user
- Catch and relay select generic Python errors
- Author & footer setting changes
- Fix eval timeout

P.S. You should probably squash these commits on merge